### PR TITLE
Add planetarium unlock checker

### DIFF
--- a/content/items.xml
+++ b/content/items.xml
@@ -1,0 +1,3 @@
+<items gfxroot="gfx/items/" version="1">
+	<trinket achievement="406" name="Planetarium Unlock Checker" description="" gfx="" />
+</items>

--- a/main.lua
+++ b/main.lua
@@ -189,14 +189,14 @@ end
 
 function mod:unlockCheck(player)
 	self.storage.arePlanetariumsUnlocked = nil
-	if game:GetFrameCount() == 0 then
+	if Game():GetFrameCount() == 0 then
 		if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
 			self.storage.arePlanetariumsUnlocked = true
 		end
 	end
 end
 
-function mod:rKeyCheck()
+function mod:rKeyCheck() 
 	mod:init(false) --this should be good enough
 end
 

--- a/main.lua
+++ b/main.lua
@@ -190,8 +190,7 @@ function mod:unlockCheck(player)
 	self.storage.arePlanetariumsUnlocked = nil
 	if Game():GetFrameCount() == 0 then
 		local itemPool = Game():GetItemPool()
-		if itemPool:RemoveTrinket(TrinketType.TRINKET_TELESCOPE_LENS) then -- removing trinkets from the pool returns true only if the trinket is unlocked, which can be used to check for if the planetarium is unlocked as well
-			itemPool:ResetTrinkets() -- reset trinkets so you can actually get telescope lens in the game still
+		if itemPool:RemoveTrinket(Isaac.GetTrinketIdByName("Planetarium Unlock Checker")) then
 			self.storage.arePlanetariumsUnlocked = true
 		end
 	end

--- a/main.lua
+++ b/main.lua
@@ -189,8 +189,10 @@ end
 
 function mod:unlockCheck(player)
 	self.storage.arePlanetariumsUnlocked = nil
-	if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
-		self.storage.arePlanetariumsUnlocked = true
+	if game:GetFrameCount() == 0 then
+		if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
+			self.storage.arePlanetariumsUnlocked = true
+		end
 	end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -1,8 +1,7 @@
 PlanetariumChance = RegisterMod("Planetarium Chance", 1)
 local mod = PlanetariumChance
-local json = require("json")
 
-mod.initialized=false;
+mod.initialized=false
 
 function mod:onRender(shaderName)
 	if shaderName ~= "UI_DrawPlanetariumChance_DummyShader" then return end
@@ -196,7 +195,7 @@ function mod:unlockCheck(player)
 	end
 end
 
-function mod:rKeyCheck() 
+function mod:rKeyCheck()
 	mod:init(false) --this should be good enough
 end
 

--- a/main.lua
+++ b/main.lua
@@ -49,19 +49,16 @@ end
 
 function mod:init(continued)
 	self.storage.canPlanetariumsSpawn = nil
-	if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
-		if not Game():IsGreedMode() then -- check greed mode since planetariums cannot spawn in greed mode
-			local rooms = Game():GetLevel():GetRooms()
-			for i = 0, rooms.Size - 1 do
-				local room = rooms:Get(i).Data
-				if room.Type == RoomType.ROOM_TREASURE then -- check if there is a treasure room on the floor since planetariums require treasure rooms in the game to spawn (for challenges)
-					self.storage.canPlanetariumsSpawn = true
-					break
-				end
+	if not Game():IsGreedMode() then -- check greed mode since planetariums cannot spawn in greed mode
+		local rooms = Game():GetLevel():GetRooms()
+		for i = 0, rooms.Size - 1 do
+			local room = rooms:Get(i).Data
+			if room.Type == RoomType.ROOM_TREASURE then -- check if there is a treasure room on the floor since planetariums require treasure rooms in the game to spawn (for challenges)
+				self.storage.canPlanetariumsSpawn = true
+				break
 			end
 		end
 	end
-
 	
 	self.storage.currentFloorSpawnChance = nil
 
@@ -96,7 +93,7 @@ function mod:updatePlanetariumChance()
 		self.storage.currentFloorSpawnChance = 0;
 	end
 	
-	if level:IsAscent() or not self.storage.canPlanetariumsSpawn then
+	if level:IsAscent() or not self.storage.canPlanetariumsSpawn or not self.storage.arePlanetariumsUnlocked then
 		self.storage.currentFloorSpawnChance = 0
 	end
 		
@@ -190,6 +187,13 @@ function mod:updateCheck()
 	end
 end
 
+function mod:unlockCheck(player)
+	self.storage.arePlanetariumsUnlocked = nil
+	if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
+		self.storage.arePlanetariumsUnlocked = true
+	end
+end
+
 function mod:rKeyCheck()
 	mod:init(false) --this should be good enough
 end
@@ -271,7 +275,7 @@ mod:AddCallback(ModCallbacks.MC_GET_SHADER_PARAMS, mod.onRender)
 
 mod:AddCallback(ModCallbacks.MC_POST_UPDATE, mod.updateCheck)
 
---check for R Key use and run init if used
+mod:AddCallback(ModCallbacks.MC_POST_PLAYER_INIT, mod.unlockCheck)
 mod:AddCallback(ModCallbacks.MC_USE_ITEM, mod.rKeyCheck, CollectibleType.COLLECTIBLE_R_KEY)
 
 --Custom Shader Fix by AgentCucco

--- a/main.lua
+++ b/main.lua
@@ -189,7 +189,9 @@ end
 function mod:unlockCheck(player)
 	self.storage.arePlanetariumsUnlocked = nil
 	if Game():GetFrameCount() == 0 then
-		if isTrinketUnlocked(TrinketType.TRINKET_TELESCOPE_LENS) then -- check if telescope lens is unlocked, since it can be used to check if planetariums in general are unlocked
+		local itemPool = Game():GetItemPool()
+		if itemPool:RemoveTrinket(TrinketType.TRINKET_TELESCOPE_LENS) then -- removing trinkets from the pool returns true only if the trinket is unlocked, which can be used to check for if the planetarium is unlocked as well
+			itemPool:ResetTrinkets() -- reset trinkets so you can actually get telescope lens in the game still
 			self.storage.arePlanetariumsUnlocked = true
 		end
 	end
@@ -239,25 +241,6 @@ mod:AddCallback(ModCallbacks.MC_POST_PLAYER_UPDATE, function(_, player)
 	end
 	data.lastPlayerType = playerType
 end)
-
-function isTrinketUnlocked(trinketID)
-	local itemPool = Game():GetItemPool()
-	for i= 1, GetMaxTrinketID() do
-		if Isaac.GetItemConfig():GetTrinket(i) and i ~= trinketID then
-			itemPool:RemoveTrinket(i)
-		end
-	end
-	local isUnlocked = false
-	for i = 0,1 do -- some samples to make sure
-		local trinID = itemPool:GetTrinket(false)
-		if trinID == trinketID then
-			isUnlocked = true
-			break
-		end
-	end
-	itemPool:ResetTrinkets()
-	return isUnlocked
-end
 
 --init self storage from mod namespace before any callbacks by blocking.
 function mod:initStore()

--- a/main.lua
+++ b/main.lua
@@ -56,7 +56,6 @@ function mod:init(continued)
 				local room = rooms:Get(i).Data
 				if room.Type == RoomType.ROOM_TREASURE then -- check if there is a treasure room on the floor since planetariums require treasure rooms in the game to spawn (for challenges)
 					self.storage.canPlanetariumsSpawn = true
-					print("Planetariums can spawn in this run")
 					break
 				end
 			end
@@ -200,10 +199,6 @@ end
 -- Custom Log Command
 function log(text)
 	Isaac.DebugString(tostring(text))
-end
-
-function GetMaxCollectibleID()
-    return Isaac.GetItemConfig():GetCollectibles().Size -1
 end
 
 function GetMaxTrinketID()


### PR DESCRIPTION
Now when planetariums aren't unlocked it always displays as 0%, so it doesn't mislead people into thinking they can get planetariums.