### PR TITLE
Check availability of Telescope Lens for planetarium spawns

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -56,7 +56,7 @@ end
 function mod:init(continued)
 	if not continued then
 		self.storage.canPlanetariumsSpawn = 0
-		if not Game():IsGreedMode() then -- check greed mode since planetariums cannot spawn in greed mode
+		if Isaac.GetItemConfig():GetTrinket(TrinketType.TRINKET_TELESCOPE_LENS):IsAvailable() then -- check if telescope lens is available, since if it isn't its either greed mode or planetariums are not unlocked
 			local rooms = Game():GetLevel():GetRooms()
 			for i = 0, rooms.Size - 1 do
 				local room = rooms:Get(i).Data


### PR DESCRIPTION
New API function lets us do this. It effectively allows us to check if Planetariums are unlocked, finally.