### PR TITLE
Remove HP check to ensure we cover chaos card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ disable.it.x
 /scripts/eid_savegames.lua
 /.vscode
 .luarc.json
+build/

--- a/main.lua
+++ b/main.lua
@@ -184,11 +184,9 @@ function mod:isDogmaDefeated()
 	local isDogma = Game():GetLevel():GetAbsoluteStage() == LevelStage.STAGE8 and Game():GetRoom():IsCurrentRoomLastBoss()
 	if isDogma then
 		for _,v in pairs(Isaac.GetRoomEntities()) do
-			if v:IsBoss() and v.HitPoints <= 0 then 
-				if v:GetSprite():GetAnimation() == "Death" and v:GetSprite():GetFrame() > 80 then
-					dogmaEnded = true
-					return true
-				end
+			if v:IsBoss() and v:GetSprite():GetAnimation() == "Death" and v:GetSprite():GetFrame() > 80 then
+				dogmaEnded = true
+				return true
 			end
 		end
 	end

--- a/metadata.xml
+++ b/metadata.xml
@@ -19,7 +19,7 @@ Have any ideas? Found a bug? visit the mod repository @ https://github.com/Secti
 Contributors: [url=https://steamcommunity.com/id/kittenchilly]@Kittenchilly[/url], [url=https://github.com/UnfairPath20]@UnfairPath20[/url]
     
 https://buymeacoffee.com/sectimus</description>
-    <version>10.0</version>
+    <version>10.1</version>
     <visibility>Public</visibility>
     <tag id="Lua"/>
     <tag id="Tweaks"/>


### PR DESCRIPTION
Thanks to [Dr. Coitus](https://steamcommunity.com/id/LckdFlppr) on steam for commenting about the bug:

 >Hey for some reason your dogma fix doesn't work when he is killed by a chaos card 