### PR TITLE
Fix coords offset with Rep+, disable with repentogon

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -104,6 +104,7 @@ function mod:init(continued)
 	if REPENTOGON and self.storage.repentogonEnabled == nil then
 		print("REPENTOGON has its own implementation of a Planetarium Chance HUD. Disabling Planetarium Chance mod in favor of REPENTOGON's.")
 		self.storage.repentogonEnabled = true;
+		Options.StatHUDPlanetarium = true;
 	end
 	
 	self.storage.available = Isaac.GetItemConfig():GetTrinket(TrinketType.TRINKET_TELESCOPE_LENS):IsAvailable() and 1 or 0

--- a/main.lua
+++ b/main.lua
@@ -107,6 +107,8 @@ function mod:init(continued)
 		Options.StatHUDPlanetarium = true;
 	end
 	
+	self.storage.repentogonEnabled = nil
+
 	self.storage.available = Isaac.GetItemConfig():GetTrinket(TrinketType.TRINKET_TELESCOPE_LENS):IsAvailable() and 1 or 0
 	dogmaEnded = false
 	if not continued then

--- a/main.lua
+++ b/main.lua
@@ -105,10 +105,10 @@ function mod:init(continued)
 		print("REPENTOGON has its own implementation of a Planetarium Chance HUD. Disabling Planetarium Chance mod in favor of REPENTOGON's.")
 		self.storage.repentogonEnabled = true;
 		Options.StatHUDPlanetarium = true;
+	else
+		self.storage.repentogonEnabled = nil
 	end
 	
-	self.storage.repentogonEnabled = nil
-
 	self.storage.available = Isaac.GetItemConfig():GetTrinket(TrinketType.TRINKET_TELESCOPE_LENS):IsAvailable() and 1 or 0
 	dogmaEnded = false
 	if not continued then

--- a/main.lua
+++ b/main.lua
@@ -209,7 +209,7 @@ function mod:shouldDeHook()
 		-- Game():IsGreedMode() //The chance should still display on Greed Mode even if its 0 for consistency with the rest of the HUD.
 	}
 
-	return reqs[1] or reqs[2] or reqs[3] or reqs[4] or reqs[5] or reqs[6]
+	return reqs[1] or reqs[2] or reqs[3] or reqs[4] or reqs[5] or reqs[6] or reqs[7]
 end
 
 function mod:updatePosition()


### PR DESCRIPTION
Rep+ shifts the found hud down 2 pixels, so we account for that.
Repentogon has its own implementation of planetarium chance. I have seen so many people use both at the same time and not realize they both overlap (which is ugly), and that you don't need one if you have the other. Thats why I disable (or prevent ours from showing up) if repentogon is detected. It isn't feasible for repentogon to disable theirs in favor of ours, since theirs is a full asm patch.